### PR TITLE
Fix plugin not compiling in future BD version

### DIFF
--- a/SpotifyEnhance/SpotifyEnhance.plugin.js
+++ b/SpotifyEnhance/SpotifyEnhance.plugin.js
@@ -449,7 +449,7 @@ function sanitizeSpotifyLink(link) {
 		return link;
 	}
 }
-const activityPanelClasses = getModule(Filters.byProps("activityPanel", "panels"), { searchExports: false });
+const activityPanelClasses = getModule(Filters.byKeys("activityPanel", "panels"), { searchExports: false });
 const getFluxContainer = (() => {
 	let userAreaFluxContainer = undefined;
 


### PR DESCRIPTION
Plugin will not compile in the future due to using the deprecated `Filter.byProps` wich will be sobstitute with `FIlter.byKeys`